### PR TITLE
create new ScriptEngine bindings on regex eval to ensure threadsafe scan

### DIFF
--- a/src/main/java/org/jshint/Lexer.java
+++ b/src/main/java/org/jshint/Lexer.java
@@ -2032,7 +2032,7 @@ public class Lexer
 		// and it doesn't require external dependency so it's used as a validator of javascript regular expressions
 		try
 		{
-			jsEngine.eval("/" + body.toString() + "/" + es5Flags);
+			jsEngine.eval("/" + body.toString() + "/" + es5Flags, jsEngine.createBindings());
 		}
 		catch (Exception err)
 		{


### PR DESCRIPTION
As the ScriptEngine (`jsEngine`) is static, this creates a new set of bindings per invocation of `eval()` to ensure thread safety; addressing #4. 